### PR TITLE
Fix currency inputs

### DIFF
--- a/components/ui/form-fields/NumberField.tsx
+++ b/components/ui/form-fields/NumberField.tsx
@@ -35,10 +35,8 @@ export function NumberField({
     const value = form.getValues(name);
     if (value !== undefined && value !== null) {
       setDisplayValue(isCurrency ? formatCurrency(value) : value.toString());
-    } else {
-      setDisplayValue("");
     }
-  }, [form, name, isCurrency, form.watch(name)]);
+  }, [form, name, isCurrency]);
 
   const formatCurrency = (value: number): string => {
     return new Intl.NumberFormat("en-US", {

--- a/components/ui/form-fields/NumberField.tsx
+++ b/components/ui/form-fields/NumberField.tsx
@@ -29,14 +29,21 @@ export function NumberField({
   isCurrency = false,
 }: NumberFieldProps) {
   const [displayValue, setDisplayValue] = useState<string>("");
+  const [isFocused, setIsFocused] = useState(false);
 
-  // Initialize display value from form value
+  const watchedValue = form.watch(name);
+
+  // Initialize display value from form value only when not focused
   useEffect(() => {
-    const value = form.getValues(name);
-    if (value !== undefined && value !== null) {
-      setDisplayValue(isCurrency ? formatCurrency(value) : value.toString());
+    if (!isFocused) {
+      const value = watchedValue;
+      if (value !== undefined && value !== null && value !== "") {
+        setDisplayValue(isCurrency ? formatCurrency(value) : value.toString());
+      } else {
+        setDisplayValue("");
+      }
     }
-  }, [form, name, isCurrency]);
+  }, [watchedValue, isCurrency, isFocused]);
 
   const formatCurrency = (value: number): string => {
     return new Intl.NumberFormat("en-US", {
@@ -88,6 +95,7 @@ export function NumberField({
               }
             }}
             onBlur={(e) => {
+              setIsFocused(false);
               const value = e.target.value;
               if (value) {
                 const numericValue = parseCurrency(value);
@@ -100,6 +108,7 @@ export function NumberField({
               }
             }}
             onFocus={(e) => {
+              setIsFocused(true);
               // When focusing, show the raw number without formatting
               const value = field.value;
               if (value !== undefined && value !== null) {


### PR DESCRIPTION
This PR improves the user experience for currency inputs. Now, prefilled values show up right away when the form loads, and the input only formats as currency after you finish editing (on blur). This makes it easier to type and edit amounts without unexpected formatting while you type.